### PR TITLE
Fix queue counter and cub temp allocation

### DIFF
--- a/primitives/Queue/TwoLevelQueue.i.cuh
+++ b/primitives/Queue/TwoLevelQueue.i.cuh
@@ -167,8 +167,8 @@ __global__ void swapKernel(int2* d_counters) {
 template<typename T>
 void TwoLevelQueue<T>::sync() const noexcept {
     cuMemcpyToHost(_d_counters, _h_counters);
-    assert(_h_counters.x < _max_allocated_items && "TwoLevelQueue too small");
-    assert(_h_counters.y < _max_allocated_items && "TwoLevelQueue too small");
+    assert(_h_counters.x <= _max_allocated_items && "TwoLevelQueue too small");
+    assert(_h_counters.y <= _max_allocated_items && "TwoLevelQueue too small");
 }
 
 template<typename T>

--- a/xlib/src/Device/Primitives/CubWrapper.cu
+++ b/xlib/src/Device/Primitives/CubWrapper.cu
@@ -582,7 +582,8 @@ void CubExclusiveSum<T>::initialize(const int max_items) noexcept {
     T* d_in = nullptr, *d_out = nullptr;
     cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes,
                                   d_in, d_out, _num_items);
-    cuMalloc(_d_temp_storage, temp_storage_bytes);
+    if (temp_storage_bytes)
+        cuMalloc(_d_temp_storage, temp_storage_bytes);
 }
 
 //------------------------------------------------------------------------------
@@ -661,11 +662,12 @@ template<typename T>
 void CubInclusiveMax<T>::initialize(const int max_items) noexcept {
     CubMax max_op;
     CubWrapper::initialize(max_items);
-    size_t temp_storage_bytes;
+    size_t temp_storage_bytes = 0;
     T* d_in = nullptr, *d_out = nullptr;
     cub::DeviceScan::InclusiveScan(nullptr, temp_storage_bytes,
                                   d_in, d_out, max_op, _num_items);
-    cuMalloc(_d_temp_storage, _temp_storage_bytes);
+    if (temp_storage_bytes)
+        cuMalloc(_d_temp_storage, temp_storage_bytes);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
- Queue counters can be max
- Allocate cub temp storage only if non-zero
- _temp_storage_bytes is a different variable. Change it to
  temp_storage_temp_storage_bytes, which is the one that is actually
computed