### PR TITLE
[REVIEW] - Replacing all thrust calls with RMM

### DIFF
--- a/hornet/include/Core/BatchUpdate/BatchUpdate.cuh
+++ b/hornet/include/Core/BatchUpdate/BatchUpdate.cuh
@@ -50,6 +50,12 @@
 #include "BatchUpdateKernels.cuh"
 #include "../Static/Static.cuh"
 
+#include <rmm/rmm.h>
+#include <rmm/thrust_rmm_allocator.h>
+
+using namespace rmm;
+
+
 #define CUDA_TRY_CALL( call ) 									                            \
 {                                                                     \
     cudaError_t cudaStatus = call;                                    \
@@ -127,30 +133,30 @@ class BatchUpdate<
 
     bool current_edge;
 
-    thrust::device_vector<degree_t> range[2];
+    rmm::device_vector<degree_t> range[2];
 
-    thrust::device_vector<vid_t>    unique_sources;
-    thrust::device_vector<degree_t> unique_degrees;
-    thrust::device_vector<degree_t> duplicate_flag;
-    thrust::device_vector<degree_t>  batch_offsets;
-    thrust::device_vector<degree_t>  graph_offsets;
+    rmm::device_vector<vid_t>    unique_sources;
+    rmm::device_vector<degree_t> unique_degrees;
+    rmm::device_vector<degree_t> duplicate_flag;
+    rmm::device_vector<degree_t>  batch_offsets;
+    rmm::device_vector<degree_t>  graph_offsets;
 
     xlib::CubRunLengthEncode<vid_t>  cub_runlength;
     xlib::CubExclusiveSum<degree_t>  cub_prefixsum;
     xlib::CubInclusiveMax<degree_t>  cub_prefixmax;
 
-    thrust::device_vector<vid_t>   realloc_sources;
+    rmm::device_vector<vid_t>   realloc_sources;
 
     SoAData<TypeList<degree_t, xlib::byte_t*, degree_t, degree_t>, DeviceType::DEVICE> vertex_access[2];
     SoAData<TypeList<degree_t, xlib::byte_t*, degree_t, degree_t>, DeviceType::HOST> host_vertex_access[2];
 
-    thrust::device_vector<degree_t> realloc_sources_count_buffer;
+    rmm::device_vector<degree_t> realloc_sources_count_buffer;
 
     //Functions
 
-    thrust::device_vector<vid_t>& in_range() noexcept;
+    rmm::device_vector<vid_t>& in_range() noexcept;
 
-    thrust::device_vector<vid_t>& out_range() noexcept;
+    rmm::device_vector<vid_t>& out_range() noexcept;
 
     void flip_resource(void) noexcept;
 
@@ -162,10 +168,10 @@ class BatchUpdate<
     degree_t get_unique_sources_meta_data(
             vid_t * const batch_src,
             const degree_t nE,
-            thrust::device_vector<vid_t>& unique_sources,
-            thrust::device_vector<degree_t>& unique_degrees,
-            thrust::device_vector<degree_t>& batch_offsets,
-            thrust::device_vector<degree_t>& graph_offsets,
+            rmm::device_vector<vid_t>& unique_sources,
+            rmm::device_vector<degree_t>& unique_degrees,
+            rmm::device_vector<degree_t>& batch_offsets,
+            rmm::device_vector<degree_t>& graph_offsets,
             hornet::HornetDevice<TypeList<VertexMetaTypes...>, TypeList<EdgeMetaTypes...>, vid_t, degree_t>& hornet_device) noexcept;
 
     template <typename... VertexMetaTypes>
@@ -173,11 +179,11 @@ class BatchUpdate<
         vid_t * const batch_src,
         vid_t * const batch_dst,
         const degree_t nE,
-        thrust::device_vector<vid_t>& unique_sources,
-        thrust::device_vector<degree_t>& batch_src_offsets,
-        thrust::device_vector<degree_t>& batch_dst_offsets,
-        thrust::device_vector<degree_t>& batch_dst_degrees,
-        thrust::device_vector<degree_t>& graph_offsets,
+        rmm::device_vector<vid_t>& unique_sources,
+        rmm::device_vector<degree_t>& batch_src_offsets,
+        rmm::device_vector<degree_t>& batch_dst_offsets,
+        rmm::device_vector<degree_t>& batch_dst_degrees,
+        rmm::device_vector<degree_t>& graph_offsets,
         hornet::HornetDevice<TypeList<VertexMetaTypes...>, TypeList<EdgeMetaTypes...>, vid_t, degree_t>& hornet_device) noexcept;
 
     template <typename... VertexMetaTypes>
@@ -261,12 +267,12 @@ class BatchUpdate<
     void markOverwriteSrcDst(
         hornet::HornetDevice<TypeList<VertexMetaTypes...>, TypeList<EdgeMetaTypes...>, vid_t, degree_t>& hornet_device,
         vid_t * batch_src,
-        thrust::device_vector<vid_t> &unique_sources,
-        thrust::device_vector<degree_t>& batch_src_degrees,
-        thrust::device_vector<degree_t>& destination_edges,
-        thrust::device_vector<degree_t>& destination_edges_flag,
-        thrust::device_vector<degree_t>& source_edge_flag,
-        thrust::device_vector<degree_t>& source_edge_offset) noexcept;
+        rmm::device_vector<vid_t> &unique_sources,
+        rmm::device_vector<degree_t>& batch_src_degrees,
+        rmm::device_vector<degree_t>& destination_edges,
+        rmm::device_vector<degree_t>& destination_edges_flag,
+        rmm::device_vector<degree_t>& source_edge_flag,
+        rmm::device_vector<degree_t>& source_edge_offset) noexcept;
 
     degree_t nE(void) const noexcept;
 };

--- a/hornet/include/Core/BatchUpdate/BatchUpdate.i.cuh
+++ b/hornet/include/Core/BatchUpdate/BatchUpdate.i.cuh
@@ -35,6 +35,9 @@
  */
 #include "Host/Metaprogramming.hpp"
 
+#include <rmm/rmm.h>
+#include <rmm/thrust_rmm_allocator.h>
+
 template <typename T>
 void print_vec(thrust::device_vector<T>& vec) {
         thrust::copy(vec.begin(), vec.end(), std::ostream_iterator<T>(std::cout, " "));
@@ -262,7 +265,7 @@ remove_duplicates_edges_only(
                 out_ptr.template get<0>(), out_ptr.template get<1>()));
     auto end_ptr =
         thrust::unique_copy(
-                thrust::device,
+                rmm::exec_policy(0)->on(0),
                 begin_in_tuple, begin_in_tuple + nE,
                 begin_out_tuple,
                 IsSrcDstEqual());
@@ -298,7 +301,7 @@ remove_duplicates(
                 out_ptr.template get<0>(), out_ptr.template get<1>(), out_ptr.template get<2>()));
     auto end_ptr =
         thrust::unique_copy(
-                thrust::device,
+                rmm::exec_policy(0)->on(0),
                 begin_in_tuple, begin_in_tuple + nE,
                 begin_out_tuple,
                 IsSrcDstEqual());
@@ -325,7 +328,7 @@ remove_duplicates(
                 out_ptr.template get<0>(), out_ptr.template get<1>(), range_copy.begin()));
     auto end_ptr =
         thrust::unique_copy(
-                thrust::device,
+                rmm::exec_policy(0)->on(0),
                 begin_in_tuple, begin_in_tuple + nE,
                 begin_out_tuple,
                 IsSrcDstEqual());
@@ -686,7 +689,7 @@ locateEdgesToBeErased(
     auto out_ptr_tuple = thrust::make_zip_iterator(thrust::make_tuple(
                 batch_src_out, destination_edges.begin()));
                 //realloc_sources.begin(), destination_edges.begin()));
-    _nE = thrust::copy_if(thrust::device,
+    _nE = thrust::copy_if(rmm::exec_policy(0)->on(0),
             ptr_tuple, ptr_tuple + _nE,
             batch_erase_flag.begin(),
             out_ptr_tuple,

--- a/hornet/include/Core/BatchUpdate/BatchUpdate.i.cuh
+++ b/hornet/include/Core/BatchUpdate/BatchUpdate.i.cuh
@@ -37,15 +37,16 @@
 
 #include <rmm/rmm.h>
 #include <rmm/thrust_rmm_allocator.h>
+using namespace rmm;
 
 template <typename T>
-void print_vec(thrust::device_vector<T>& vec) {
+void print_vec(rmm::device_vector<T>& vec) {
         thrust::copy(vec.begin(), vec.end(), std::ostream_iterator<T>(std::cout, " "));
         std::cout<<"\n";
 }
 
 template <typename T>
-void print_vec(thrust::device_vector<T>& d, std::string name) {
+void print_vec(rmm::device_vector<T>& d, std::string name) {
   std::cout<<"\n"<<name<<" : ";
   thrust::copy(d.begin(), d.end(), std::ostream_iterator<T>(std::cout, " "));
   std::cout<<"\n";
@@ -204,7 +205,7 @@ out_edge(void) noexcept {
 
 template <typename... EdgeMetaTypes,
     typename vid_t, typename degree_t>
-thrust::device_vector<vid_t>&
+rmm::device_vector<vid_t>&
 BATCH_UPDATE::
 in_range(void) noexcept {
     return range[current_edge];
@@ -212,7 +213,7 @@ in_range(void) noexcept {
 
 template <typename... EdgeMetaTypes,
     typename vid_t, typename degree_t>
-thrust::device_vector<vid_t>&
+rmm::device_vector<vid_t>&
 BATCH_UPDATE::
 out_range(void) noexcept {
     return range[!current_edge];
@@ -257,8 +258,8 @@ remove_duplicates_edges_only(
         CSoAPtr<EdgeTypes...> in_ptr,
         CSoAPtr<EdgeTypes...> out_ptr,
         degree_t& nE,
-        thrust::device_vector<degree_t>& range,
-        thrust::device_vector<degree_t>& range_copy) {
+        rmm::device_vector<degree_t>& range,
+        rmm::device_vector<degree_t>& range_copy) {
     auto begin_in_tuple = thrust::make_zip_iterator(thrust::make_tuple(
                 in_ptr.template get<0>(), in_ptr.template get<1>()));
     auto begin_out_tuple = thrust::make_zip_iterator(thrust::make_tuple(
@@ -281,8 +282,8 @@ remove_duplicates(
         CSoAPtr<EdgeTypes...> in_ptr,
         CSoAPtr<EdgeTypes...> out_ptr,
         degree_t& nE,
-        thrust::device_vector<degree_t>& range,
-        thrust::device_vector<degree_t>& range_copy) {
+        rmm::device_vector<degree_t>& range,
+        rmm::device_vector<degree_t>& range_copy) {
     remove_duplicates_edges_only(in_ptr, out_ptr, nE, range, range_copy);
 }
 
@@ -293,8 +294,8 @@ remove_duplicates(
         CSoAPtr<EdgeTypes...> in_ptr,
         CSoAPtr<EdgeTypes...> out_ptr,
         degree_t& nE,
-        thrust::device_vector<degree_t>& range,
-        thrust::device_vector<degree_t>& range_copy) {
+        rmm::device_vector<degree_t>& range,
+        rmm::device_vector<degree_t>& range_copy) {
     auto begin_in_tuple = thrust::make_zip_iterator(thrust::make_tuple(
                 in_ptr.template get<0>(), in_ptr.template get<1>(), in_ptr.template get<2>()));
     auto begin_out_tuple = thrust::make_zip_iterator(thrust::make_tuple(
@@ -317,8 +318,8 @@ remove_duplicates(
         CSoAPtr<EdgeTypes...> in_ptr,
         CSoAPtr<EdgeTypes...> out_ptr,
         degree_t& nE,
-        thrust::device_vector<degree_t>& range,
-        thrust::device_vector<degree_t>& range_copy) {
+        rmm::device_vector<degree_t>& range,
+        rmm::device_vector<degree_t>& range_copy) {
     range.resize(nE);
     range_copy.resize(nE);
     thrust::sequence(range.begin(), range.end());
@@ -402,10 +403,10 @@ BATCH_UPDATE::
 get_unique_sources_meta_data(
         vid_t * const batch_src,
         const degree_t nE,
-        thrust::device_vector<vid_t>& unique_sources,
-        thrust::device_vector<degree_t>& unique_degrees,
-        thrust::device_vector<degree_t>& batch_offsets,
-        thrust::device_vector<degree_t>& graph_offsets,
+        rmm::device_vector<vid_t>& unique_sources,
+        rmm::device_vector<degree_t>& unique_degrees,
+        rmm::device_vector<degree_t>& batch_offsets,
+        rmm::device_vector<degree_t>& graph_offsets,
         hornet::HornetDevice<TypeList<VertexMetaTypes...>, TypeList<EdgeMetaTypes...>, vid_t, degree_t>& hornet_device) noexcept {
 
     unique_sources.resize(_nE);
@@ -445,11 +446,11 @@ get_unique_sources_meta_data_erase(
         vid_t * const batch_src,
         vid_t * const batch_dst,
         const degree_t nE,
-        thrust::device_vector<vid_t>& unique_sources,
-        thrust::device_vector<degree_t>& batch_src_offsets,
-        thrust::device_vector<degree_t>& batch_dst_offsets,
-        thrust::device_vector<degree_t>& batch_dst_degrees,
-        thrust::device_vector<degree_t>& graph_offsets,
+        rmm::device_vector<vid_t>& unique_sources,
+        rmm::device_vector<degree_t>& batch_src_offsets,
+        rmm::device_vector<degree_t>& batch_dst_offsets,
+        rmm::device_vector<degree_t>& batch_dst_degrees,
+        rmm::device_vector<degree_t>& graph_offsets,
         hornet::HornetDevice<TypeList<VertexMetaTypes...>, TypeList<EdgeMetaTypes...>, vid_t, degree_t>& hornet_device) noexcept {
 
     ////DESTINATION BATCH DEGREES
@@ -532,15 +533,15 @@ template <typename... VertexMetaTypes>
 void
 BATCH_UPDATE::
 overWriteEdges(hornet::HornetDevice<TypeList<VertexMetaTypes...>, TypeList<EdgeMetaTypes...>, vid_t, degree_t>& hornet_device) noexcept {
-    thrust::device_vector<degree_t>& destination_edges = range[1];//reuse
-    thrust::device_vector<degree_t>& destination_edges_flag = range[0];
-    thrust::device_vector<degree_t>& source_edges_flag = duplicate_flag;
-    thrust::device_vector<degree_t>& source_edges_offset = graph_offsets;
+    rmm::device_vector<degree_t>& destination_edges = range[1];//reuse
+    rmm::device_vector<degree_t>& destination_edges_flag = range[0];
+    rmm::device_vector<degree_t>& source_edges_flag = duplicate_flag;
+    rmm::device_vector<degree_t>& source_edges_offset = graph_offsets;
 
     auto in_ptr = in_edge().get_soa_ptr();
     vid_t * batch_src = in_ptr.template get<0>();
 
-    thrust::device_vector<degree_t>& batch_src_degrees = unique_degrees;
+    rmm::device_vector<degree_t>& batch_src_degrees = unique_degrees;
     unique_sources.resize(_nE);
     batch_src_degrees.resize(_nE);
     degree_t unique_sources_count = cub_runlength.run(batch_src, _nE,
@@ -577,15 +578,15 @@ BATCH_UPDATE::
 markOverwriteSrcDst(
         hornet::HornetDevice<TypeList<VertexMetaTypes...>, TypeList<EdgeMetaTypes...>, vid_t, degree_t>& hornet_device,
         vid_t * batch_src,
-        thrust::device_vector<vid_t> &unique_sources,
-        thrust::device_vector<degree_t>& batch_src_degrees,
-        thrust::device_vector<degree_t>& destination_edges,
-        thrust::device_vector<degree_t>& destination_edges_flag,
-        thrust::device_vector<degree_t>& source_edges_flag,
-        thrust::device_vector<degree_t>& source_edges_offset
+        rmm::device_vector<vid_t> &unique_sources,
+        rmm::device_vector<degree_t>& batch_src_degrees,
+        rmm::device_vector<degree_t>& destination_edges,
+        rmm::device_vector<degree_t>& destination_edges_flag,
+        rmm::device_vector<degree_t>& source_edges_flag,
+        rmm::device_vector<degree_t>& source_edges_offset
         ) noexcept {
 
-    thrust::device_vector<degree_t>& batch_src_offsets = batch_offsets;
+    rmm::device_vector<degree_t>& batch_src_offsets = batch_offsets;
     batch_src_offsets.resize(batch_src_degrees.size() + 1);
     thrust::copy(batch_src_degrees.begin(), batch_src_degrees.end(), batch_src_offsets.begin());
     cub_prefixsum.run(batch_src_offsets.data().get(), batch_src_degrees.size() + 1);
@@ -650,9 +651,9 @@ locateEdgesToBeErased(
     auto in_ptr = in_edge().get_soa_ptr();
     vid_t * batch_src = in_ptr.template get<0>();
     vid_t * batch_dst = in_ptr.template get<1>();
-    thrust::device_vector<degree_t>& batch_src_offsets = batch_offsets;
-    thrust::device_vector<degree_t>& batch_dst_offsets = unique_degrees;
-    thrust::device_vector<degree_t>& batch_dst_degrees  = duplicate_flag;
+    rmm::device_vector<degree_t>& batch_src_offsets = batch_offsets;
+    rmm::device_vector<degree_t>& batch_dst_offsets = unique_degrees;
+    rmm::device_vector<degree_t>& batch_dst_degrees  = duplicate_flag;
 
     degree_t total_work =
         get_unique_sources_meta_data_erase(
@@ -665,8 +666,8 @@ locateEdgesToBeErased(
                 hornet_device);
     if (total_work == 0) { return; }
 
-    thrust::device_vector<degree_t>& erase_edge_location = range[0];//reuse
-    thrust::device_vector<degree_t>& batch_erase_flag = unique_degrees;//reuse
+    rmm::device_vector<degree_t>& erase_edge_location = range[0];//reuse
+    rmm::device_vector<degree_t>& batch_erase_flag = unique_degrees;//reuse
     locate_erased_edges(hornet_device,
             unique_sources,
             batch_dst,
@@ -681,7 +682,7 @@ locateEdgesToBeErased(
     auto out_ptr = out_edge().get_soa_ptr();
     vid_t * batch_src_out = out_ptr.template get<0>();
 
-    thrust::device_vector<degree_t>& destination_edges = range[1];//reuse
+    rmm::device_vector<degree_t>& destination_edges = range[1];//reuse
     //realloc_sources.resize(_nE);
     destination_edges.resize(_nE);
     auto ptr_tuple = thrust::make_zip_iterator(thrust::make_tuple(
@@ -862,8 +863,8 @@ BATCH_UPDATE::
 print(bool sort) noexcept {
     auto ptr = in_edge().get_soa_ptr();
     std::cout<<"src, dst : "<<size()<<"\n";
-    thrust::device_vector<vid_t> src(size());
-    thrust::device_vector<vid_t> dst(size());
+    rmm::device_vector<vid_t> src(size());
+    rmm::device_vector<vid_t> dst(size());
     thrust::copy(ptr.template get<0>(), ptr.template get<0>() + size(), src.begin());
     thrust::copy(ptr.template get<1>(), ptr.template get<1>() + size(), dst.begin());
     if (!sort) {

--- a/hornet/include/Core/HornetInitialize/HornetInitialize.i.cuh
+++ b/hornet/include/Core/HornetInitialize/HornetInitialize.i.cuh
@@ -35,6 +35,11 @@
  */
 #include "../SoA/SoAData.cuh"
 
+#include <rmm/rmm.h>
+#include <rmm/thrust_rmm_allocator.h>
+
+using namespace rmm;
+
 namespace hornet {
 namespace gpu {
 
@@ -160,7 +165,7 @@ print(void) {
         degree_t v_degree = ptr[i].template get<0>();
         std::cerr<<i<<" : "<<v_degree<<" | ";
         if (v_degree != 0) {
-          thrust::device_vector<degree_t> dst(v_degree);
+          rmm::device_vector<degree_t> dst(v_degree);
           vid_t * dst_ptr = reinterpret_cast<vid_t*>(ptr[i].template get<1>()) + ptr[i].template get<2>();
           thrust::copy(dst_ptr, dst_ptr + v_degree, dst.begin());
           thrust::copy(dst.begin(), dst.end(), std::ostream_iterator<vid_t>(std::cerr, " "));

--- a/hornet/include/Core/HornetInitialize/HornetStaticInitialize.i.cuh
+++ b/hornet/include/Core/HornetInitialize/HornetStaticInitialize.i.cuh
@@ -1,5 +1,10 @@
 #include "../SoA/SoAData.cuh"
 
+#include <rmm/rmm.h>
+#include <rmm/thrust_rmm_allocator.h>
+
+using namespace rmm;
+
 namespace hornet {
 namespace gpu {
 
@@ -100,7 +105,7 @@ print(void) {
     for (int i = 0; i < _nV; ++i) {
         degree_t v_degree = ptr[i].template get<0>();
         std::cout<<i<<" : "<<v_degree<<" | ";
-        thrust::device_vector<degree_t> dst(v_degree);
+        rmm::device_vector<degree_t> dst(v_degree);
         vid_t * dst_ptr = reinterpret_cast<vid_t*>(ptr[i].template get<1>()) + ptr[i].template get<2>();
         thrust::copy(dst_ptr, dst_ptr + v_degree, dst.begin());
         thrust::copy(dst.begin(), dst.end(), std::ostream_iterator<vid_t>(std::cout, " "));
@@ -114,7 +119,7 @@ vid_t
 HORNETSTATIC::
 max_degree_id() const noexcept {
     auto start_ptr = _vertex_data.get_soa_ptr().template get<0>();
-    auto* iter = thrust::max_element(thrust::device, start_ptr, start_ptr + _nV);
+    auto* iter = thrust::max_element(rmm::exec_policy(0)->on(0), start_ptr, start_ptr + _nV);
     if (iter == start_ptr + _nV) {
         return static_cast<vid_t>(-1);
     } else {
@@ -127,7 +132,7 @@ degree_t
 HORNETSTATIC::
 max_degree() const noexcept {
     auto start_ptr = _vertex_data.get_soa_ptr().template get<0>();
-    auto* iter = thrust::max_element(thrust::device, start_ptr, start_ptr + _nV);
+    auto* iter = thrust::max_element(rmm::exec_policy(0)->on(0), start_ptr, start_ptr + _nV);
     if (iter == start_ptr + _nV) {
         return static_cast<degree_t>(0);
     } else {

--- a/hornet/include/Core/HornetOperations/HornetQuery.i.cuh
+++ b/hornet/include/Core/HornetOperations/HornetQuery.i.cuh
@@ -5,6 +5,10 @@
 #include <thrust/execution_policy.h>
 #include "../SoA/SoAData.cuh"
 
+#include <rmm/rmm.h>
+#include <rmm/thrust_rmm_allocator.h>
+
+
 namespace hornet {
 namespace gpu {
   template <typename... VertexMetaTypes, typename... EdgeMetaTypes, typename vid_t, typename degree_t>
@@ -12,7 +16,7 @@ namespace gpu {
   HORNET::
   max_degree_id() const noexcept {
       auto start_ptr = _vertex_data.get_soa_ptr().template get<0>();
-      auto* iter = thrust::max_element(thrust::device, start_ptr, start_ptr + _nV);
+      auto* iter = thrust::max_element(rmm::exec_policy(0)->on(0), start_ptr, start_ptr + _nV);
       if (iter == start_ptr + _nV) {
           return static_cast<vid_t>(-1);
       } else {
@@ -25,7 +29,7 @@ namespace gpu {
   HORNET::
   max_degree() const noexcept {
       auto start_ptr = _vertex_data.get_soa_ptr().template get<0>();
-      auto* iter = thrust::max_element(thrust::device, start_ptr, start_ptr + _nV);
+      auto* iter = thrust::max_element(rmm::exec_policy(0)->on(0), start_ptr, start_ptr + _nV);
       if (iter == start_ptr + _nV) {
           return static_cast<degree_t>(0);
       } else {
@@ -79,8 +83,8 @@ namespace gpu {
 
     thrust::device_vector<degree_t> offset(nV() + 1);
     auto start_ptr = _vertex_data.get_soa_ptr().template get<0>();
-    thrust::copy(thrust::device, start_ptr, start_ptr + _nV, offset.begin());
-    thrust::exclusive_scan(thrust::device, offset.begin(), offset.end(), offset.begin());
+    thrust::copy(rmm::exec_policy(0)->on(0), start_ptr, start_ptr + _nV, offset.begin());
+    thrust::exclusive_scan(rmm::exec_policy(0)->on(0), offset.begin(), offset.end(), offset.begin());
 
     HornetDeviceT hornet_device = device();
     const int BLOCK_SIZE = 256;
@@ -125,8 +129,8 @@ namespace gpu {
 
     thrust::device_vector<degree_t> degree(nV() + 1);
     auto start_ptr = _vertex_data.get_soa_ptr().template get<0>();
-    thrust::copy(thrust::device, start_ptr, start_ptr + _nV, degree.begin());
-    thrust::exclusive_scan(thrust::device, degree.begin(), degree.end(), degree.begin());
+    thrust::copy(rmm::exec_policy(0)->on(0), start_ptr, start_ptr + _nV, degree.begin());
+    thrust::exclusive_scan(rmm::exec_policy(0)->on(0), degree.begin(), degree.end(), degree.begin());
 
     HornetDeviceT hornet_device = device();
     const int BLOCK_SIZE = 256;

--- a/hornet/include/Core/HornetOperations/HornetQuery.i.cuh
+++ b/hornet/include/Core/HornetOperations/HornetQuery.i.cuh
@@ -8,6 +8,8 @@
 #include <rmm/rmm.h>
 #include <rmm/thrust_rmm_allocator.h>
 
+using namespace rmm;
+
 
 namespace hornet {
 namespace gpu {
@@ -77,11 +79,11 @@ namespace gpu {
       return csr;
     }
 
-    thrust::device_vector<vid_t> temp_src(nE());
+    rmm::device_vector<vid_t> temp_src(nE());
     SoAData<TypeList<vid_t, EdgeMetaTypes...>, DeviceType::DEVICE> index(nE());
     SoAPtr<vid_t, vid_t, EdgeMetaTypes...> coo = concat(temp_src.data().get(), index.get_soa_ptr());
 
-    thrust::device_vector<degree_t> offset(nV() + 1);
+    rmm::device_vector<degree_t> offset(nV() + 1);
     auto start_ptr = _vertex_data.get_soa_ptr().template get<0>();
     thrust::copy(rmm::exec_policy(0)->on(0), start_ptr, start_ptr + _nV, offset.begin());
     thrust::exclusive_scan(rmm::exec_policy(0)->on(0), offset.begin(), offset.end(), offset.begin());
@@ -95,10 +97,10 @@ namespace gpu {
     if (sortAdjacencyList) {
       //SoAData<TypeList<vid_t, vid_t, EdgeMetaTypes...>, DeviceType::DEVICE> out_coo_data(nE());
       SoAData<TypeList<vid_t, EdgeMetaTypes...>, DeviceType::DEVICE> out_index(nE());
-      thrust::device_vector<vid_t> temp_out_src(nE());
+      rmm::device_vector<vid_t> temp_out_src(nE());
       SoAPtr<vid_t, vid_t, EdgeMetaTypes...> out_coo = concat(temp_out_src.data().get(), out_index.get_soa_ptr());
 
-      thrust::device_vector<degree_t> range;
+      rmm::device_vector<degree_t> range;
       if (sort_batch(coo, nE(), range, out_coo)) {
         CSR<DeviceType::DEVICE, vid_t, TypeList<EdgeMetaTypes...>, degree_t> csr(std::move(offset), std::move(out_index));
         return csr;
@@ -127,7 +129,7 @@ namespace gpu {
 
     SoAData<TypeList<vid_t, vid_t, EdgeMetaTypes...>, DeviceType::DEVICE> coo_data(nE());
 
-    thrust::device_vector<degree_t> degree(nV() + 1);
+    rmm::device_vector<degree_t> degree(nV() + 1);
     auto start_ptr = _vertex_data.get_soa_ptr().template get<0>();
     thrust::copy(rmm::exec_policy(0)->on(0), start_ptr, start_ptr + _nV, degree.begin());
     thrust::exclusive_scan(rmm::exec_policy(0)->on(0), degree.begin(), degree.end(), degree.begin());
@@ -140,7 +142,7 @@ namespace gpu {
 
     if (sortAdjacencyList) {
       SoAData<TypeList<vid_t, vid_t, EdgeMetaTypes...>, DeviceType::DEVICE> out_coo_data(nE());
-      thrust::device_vector<degree_t> range;
+      rmm::device_vector<degree_t> range;
       if (sort_batch(coo_data.get_soa_ptr(), nE(), range, out_coo_data.get_soa_ptr())) {
         COO<DeviceType::DEVICE, vid_t, TypeList<EdgeMetaTypes...>, degree_t> coo(std::move(out_coo_data));
         return coo;

--- a/hornet/include/Core/SoA/SoAData.cuh
+++ b/hornet/include/Core/SoA/SoAData.cuh
@@ -44,6 +44,11 @@
 #include <thrust/gather.h>
 #include <vector>
 
+#include <rmm/rmm.h>
+#include <rmm/thrust_rmm_allocator.h>
+
+using namespace rmm;
+
 namespace hornet {
 
 template <typename, DeviceType = DeviceType::DEVICE> class SoAData;
@@ -63,7 +68,7 @@ class SoAData<TypeList<Ts...>, device_t> {
     using Map = typename
     std::conditional<
     (device_t == DeviceType::DEVICE),
-    typename thrust::device_vector<T>,
+    typename rmm::device_vector<T>,
     typename thrust::host_vector<T>>::type;
 
     SoAData(const int num_items = 0, bool initToZero = false) noexcept;

--- a/hornet/include/Core/SoA/impl/SoAData.i.cuh
+++ b/hornet/include/Core/SoA/impl/SoAData.i.cuh
@@ -34,6 +34,11 @@
  * </blockquote>}
  */
 
+#include <rmm/rmm.h>
+#include <rmm/thrust_rmm_allocator.h>
+
+using namespace rmm;
+
 namespace hornet {
 
 //==============================================================================
@@ -403,7 +408,7 @@ template<typename... Ts, DeviceType device_t>
 void
 SoAData<TypeList<Ts...>, device_t>::
 sort(void) noexcept {
-  thrust::device_vector<int> range;
+  rmm::device_vector<int> range;
   if (sizeof...(Ts) > 3) {
     SoAPtr<Ts...> temp_soa;
     RecursiveAllocate<0, sizeof...(Ts) - 1, device_t>::allocate(temp_soa, _num_items);

--- a/hornet/include/Core/SoA/impl/SoAPtr.i.cuh
+++ b/hornet/include/Core/SoA/impl/SoAPtr.i.cuh
@@ -33,6 +33,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * </blockquote>}
  */
+
+#include <rmm/rmm.h>
+#include <rmm/thrust_rmm_allocator.h>
+
 namespace hornet {
 
 //==============================================================================
@@ -267,7 +271,7 @@ struct RecursiveGather {
         const degree_t nE) {
         if (N >= SIZE) { return; }
         thrust::gather(
-                thrust::device,
+                rmm::exec_policy(0)->on(0),
                 map.begin(), map.begin() + nE,
                 src.template get<N>(),
                 dst.template get<N>());
@@ -583,11 +587,11 @@ template <template <typename...> typename Ptr, typename degree_t, typename... Ed
 void
 sort_edges(Ptr<EdgeTypes...> ptr, const degree_t nE) {
     thrust::sort_by_key(
-            thrust::device,
+            rmm::exec_policy(0)->on(0),
             ptr.template get<1>(), ptr.template get<1>() + nE,
             ptr.template get<0>());
     thrust::sort_by_key(
-            thrust::device,
+            rmm::exec_policy(0)->on(0),
             ptr.template get<0>(), ptr.template get<0>() + nE,
             ptr.template get<1>());
 }
@@ -605,11 +609,11 @@ typename std::enable_if<(3 == sizeof...(EdgeTypes)), bool>::type
 sort_batch(Ptr<EdgeTypes...> in_ptr, const degree_t nE, thrust::device_vector<degree_t>& range,
         Ptr<EdgeTypes...> out_ptr) {
     thrust::sort_by_key(
-            thrust::device,
+            rmm::exec_policy(0)->on(0),
             in_ptr.template get<1>(), in_ptr.template get<1>() + nE,
             thrust::make_zip_iterator(thrust::make_tuple(in_ptr.template get<0>(), in_ptr.template get<2>())) );
     thrust::sort_by_key(
-            thrust::device,
+            rmm::exec_policy(0)->on(0),
             in_ptr.template get<0>(), in_ptr.template get<0>() + nE,
             thrust::make_zip_iterator(thrust::make_tuple(in_ptr.template get<1>(), in_ptr.template get<2>())) );
     return false;
@@ -622,11 +626,11 @@ sort_batch(Ptr<EdgeTypes...> in_ptr, const degree_t nE, thrust::device_vector<de
     range.resize(nE);
     thrust::sequence(range.begin(), range.end());
     thrust::sort_by_key(
-            thrust::device,
+            rmm::exec_policy(0)->on(0),
             in_ptr.template get<1>(), in_ptr.template get<1>() + nE,
             thrust::make_zip_iterator(thrust::make_tuple(in_ptr.template get<0>(), range.begin())) );
     thrust::sort_by_key(
-            thrust::device,
+            rmm::exec_policy(0)->on(0),
             in_ptr.template get<0>(), in_ptr.template get<0>() + nE,
             thrust::make_zip_iterator(thrust::make_tuple(in_ptr.template get<1>(), range.begin())) );
     RecursiveCopy<0, 2>::copy(in_ptr, DeviceType::DEVICE, out_ptr, DeviceType::DEVICE, nE);

--- a/hornet/include/Core/SoA/impl/SoAPtr.i.cuh
+++ b/hornet/include/Core/SoA/impl/SoAPtr.i.cuh
@@ -37,6 +37,9 @@
 #include <rmm/rmm.h>
 #include <rmm/thrust_rmm_allocator.h>
 
+using namespace rmm;
+
+
 namespace hornet {
 
 //==============================================================================
@@ -267,7 +270,7 @@ struct RecursiveGather {
     }
     template<typename degree_t, typename Ptr>
     static void assign(Ptr src, Ptr dst,
-        const thrust::device_vector<degree_t>& map,
+        const rmm::device_vector<degree_t>& map,
         const degree_t nE) {
         if (N >= SIZE) { return; }
         thrust::gather(
@@ -287,7 +290,7 @@ struct RecursiveGather<N, N> {
         const degree_t nE) { }
     template<typename degree_t, typename Ptr>
     static void assign(Ptr src, Ptr dst,
-        const thrust::device_vector<degree_t>& map,
+        const rmm::device_vector<degree_t>& map,
         const degree_t nE) { }
 };
 
@@ -598,7 +601,7 @@ sort_edges(Ptr<EdgeTypes...> ptr, const degree_t nE) {
 
 template <template <typename...> typename Ptr, typename degree_t, typename... EdgeTypes>
 typename std::enable_if<(2 == sizeof...(EdgeTypes)), bool>::type
-sort_batch(Ptr<EdgeTypes...> in_ptr, const degree_t nE, thrust::device_vector<degree_t>& range,
+sort_batch(Ptr<EdgeTypes...> in_ptr, const degree_t nE, rmm::device_vector<degree_t>& range,
         Ptr<EdgeTypes...> out_ptr) {
     sort_edges(in_ptr, nE);
     return false;
@@ -606,7 +609,7 @@ sort_batch(Ptr<EdgeTypes...> in_ptr, const degree_t nE, thrust::device_vector<de
 
 template <template <typename...> typename Ptr, typename degree_t, typename... EdgeTypes>
 typename std::enable_if<(3 == sizeof...(EdgeTypes)), bool>::type
-sort_batch(Ptr<EdgeTypes...> in_ptr, const degree_t nE, thrust::device_vector<degree_t>& range,
+sort_batch(Ptr<EdgeTypes...> in_ptr, const degree_t nE, rmm::device_vector<degree_t>& range,
         Ptr<EdgeTypes...> out_ptr) {
     thrust::sort_by_key(
             rmm::exec_policy(0)->on(0),
@@ -621,7 +624,7 @@ sort_batch(Ptr<EdgeTypes...> in_ptr, const degree_t nE, thrust::device_vector<de
 
 template <template <typename...> typename Ptr, typename degree_t, typename... EdgeTypes>
 typename std::enable_if<(3 < sizeof...(EdgeTypes)), bool>::type
-sort_batch(Ptr<EdgeTypes...> in_ptr, const degree_t nE, thrust::device_vector<degree_t>& range,
+sort_batch(Ptr<EdgeTypes...> in_ptr, const degree_t nE, rmm::device_vector<degree_t>& range,
         Ptr<EdgeTypes...> out_ptr) {
     range.resize(nE);
     thrust::sequence(range.begin(), range.end());

--- a/hornet/include/Core/Static/Static.cuh
+++ b/hornet/include/Core/Static/Static.cuh
@@ -10,6 +10,11 @@
 #include "../Hornet.cuh"
 #include <map>
 
+#include <rmm/rmm.h>
+#include <rmm/thrust_rmm_allocator.h>
+
+using namespace rmm;
+
 namespace hornet {
 
 template <DeviceType = DeviceType::DEVICE, typename = VID_T, typename = EMPTY, typename = DEGREE_T> class COO;
@@ -29,7 +34,7 @@ public:
   using Vector = typename
   std::conditional<
   (device_t == DeviceType::DEVICE),
-  typename thrust::device_vector<T>,
+  typename rmm::device_vector<T>,
   typename thrust::host_vector<T>>::type;
 
   template <DeviceType other_device>
@@ -100,7 +105,7 @@ public:
   using Offset = typename
   std::conditional<
   (device_t == DeviceType::DEVICE),
-  typename thrust::device_vector<T>,
+  typename rmm::device_vector<T>,
   typename thrust::host_vector<T>>::type;
 
 private:

--- a/hornetsnest/include/Static/KTruss/KTruss.impl.cuh
+++ b/hornetsnest/include/Static/KTruss/KTruss.impl.cuh
@@ -37,6 +37,7 @@
 #include <rmm/thrust_rmm_allocator.h>
 
 using namespace std;
+using namespace rmm;
 
 namespace hornets_nest {
 
@@ -139,6 +140,8 @@ void KTruss::release() {
     gpu::free(hd_data().triangles_per_vertex);
     gpu::free(hd_data().counter);
     gpu::free(hd_data().active_vertices);
+    gpu::free(hd_data().src);
+    gpu::free(hd_data().dst);
 
     hd_data().is_active            = nullptr;
     hd_data().offset_array         = nullptr;
@@ -146,6 +149,8 @@ void KTruss::release() {
     hd_data().triangles_per_vertex = nullptr;
     hd_data().counter              = nullptr;
     hd_data().active_vertices      = nullptr;
+    hd_data().src                  = nullptr;
+    hd_data().dst                  = nullptr;
 
 }
 


### PR DESCRIPTION
To make cuHornet more complaint with RMM, we are replacing thrust calls with RMM.
This includes 1) thrust::device_vector with rmm::thrust_vector and 2) replacing the execution policy from thrust::device to  rmm::exec_policy(0)->on(0).
 