### PR TITLE
[BUG] Replaced deprecated [gs]et_default_resource() RMM API calls with [gs]et_current_device_resource()

### DIFF
--- a/hornet/test/HornetDeleteTest.cu
+++ b/hornet/test/HornetDeleteTest.cu
@@ -133,8 +133,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec(argc, argv);
   }

--- a/hornet/test/HornetDeleteTest.cu
+++ b/hornet/test/HornetDeleteTest.cu
@@ -134,11 +134,10 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec(argc, argv);
   }
 
   return ret;
 }
-

--- a/hornet/test/HornetInsertTest.cu
+++ b/hornet/test/HornetInsertTest.cu
@@ -90,11 +90,10 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec(argc, argv);
   }
 
   return ret;
 }
-

--- a/hornet/test/HornetInsertTest.cu
+++ b/hornet/test/HornetInsertTest.cu
@@ -89,8 +89,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec(argc, argv);
   }

--- a/hornet/test/HornetInsertTestWeighted.cu
+++ b/hornet/test/HornetInsertTestWeighted.cu
@@ -84,11 +84,10 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec(argc, argv);
   }
 
   return ret;
 }
-

--- a/hornet/test/HornetInsertTestWeighted.cu
+++ b/hornet/test/HornetInsertTestWeighted.cu
@@ -83,8 +83,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec(argc, argv);
   }

--- a/hornet/test/HornetMultiGPUInsertTest.cu
+++ b/hornet/test/HornetMultiGPUInsertTest.cu
@@ -94,11 +94,10 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec(argc, argv);
   }
 
   return ret;
 }
-

--- a/hornet/test/HornetMultiGPUInsertTest.cu
+++ b/hornet/test/HornetMultiGPUInsertTest.cu
@@ -93,8 +93,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec(argc, argv);
   }

--- a/hornetsnest/test/BCTest.cu
+++ b/hornetsnest/test/BCTest.cu
@@ -81,8 +81,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/BCTest.cu
+++ b/hornetsnest/test/BCTest.cu
@@ -82,7 +82,7 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);
@@ -91,4 +91,3 @@ int main(int argc, char* argv[]) {
 
   return ret;
 }
-

--- a/hornetsnest/test/BFSTest2.cu
+++ b/hornetsnest/test/BFSTest2.cu
@@ -57,11 +57,10 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec<hornets_nest::HornetStaticGraph,  hornets_nest::BfsTopDown2Static >(argc, argv);
   }
 
   return ret;
 }
-

--- a/hornetsnest/test/BFSTest2.cu
+++ b/hornetsnest/test/BFSTest2.cu
@@ -56,8 +56,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec<hornets_nest::HornetStaticGraph,  hornets_nest::BfsTopDown2Static >(argc, argv);
   }

--- a/hornetsnest/test/BUBFSTest2.cu
+++ b/hornetsnest/test/BUBFSTest2.cu
@@ -38,15 +38,15 @@ int exec(int argc, char* argv[]) {
 
     BfsBottomUp2 bfs_bottom_up(hornet_graph, hornet_graph_inv);
     BfsBottomUp2 bfs_top_down(hornet_graph, hornet_graph_inv);
- 
+
 	vid_t root = graph.max_out_degree_id();
 	if (argc==3)
 	  root = atoi(argv[2]);
 
     bfs_bottom_up.set_parameters(root);
     bfs_top_down.set_parameters(root);
-    
- 
+
+
     Timer<DEVICE> TM;
     cudaProfilerStart();
     TM.start();
@@ -66,7 +66,7 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);
@@ -75,4 +75,3 @@ int main(int argc, char* argv[]) {
 
   return ret;
 }
-

--- a/hornetsnest/test/BUBFSTest2.cu
+++ b/hornetsnest/test/BUBFSTest2.cu
@@ -65,8 +65,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/CCTest.cu
+++ b/hornetsnest/test/CCTest.cu
@@ -36,7 +36,7 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);
@@ -45,4 +45,3 @@ int main(int argc, char* argv[]) {
 
   return ret;
 }
-

--- a/hornetsnest/test/CCTest.cu
+++ b/hornetsnest/test/CCTest.cu
@@ -35,8 +35,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/ClusCoeffTest.cu
+++ b/hornetsnest/test/ClusCoeffTest.cu
@@ -43,8 +43,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/ClusCoeffTest.cu
+++ b/hornetsnest/test/ClusCoeffTest.cu
@@ -37,14 +37,14 @@ int exec(int argc, char* argv[]) {
 
     TM.stop();
     TM.print("Computation time:");
-  
+
     return 0;
 }
 
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);
@@ -53,4 +53,3 @@ int main(int argc, char* argv[]) {
 
   return ret;
 }
-

--- a/hornetsnest/test/CoreNumberTest.cu
+++ b/hornetsnest/test/CoreNumberTest.cu
@@ -32,7 +32,7 @@ int exec(int argc, char **argv) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/CoreNumberTest.cu
+++ b/hornetsnest/test/CoreNumberTest.cu
@@ -31,8 +31,6 @@ int exec(int argc, char **argv) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/KTrussTest.cu
+++ b/hornetsnest/test/KTrussTest.cu
@@ -100,8 +100,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/KTrussTest.cu
+++ b/hornetsnest/test/KTrussTest.cu
@@ -55,7 +55,7 @@ int exec(int argc, char* argv[]) {
 
 	  cudaSetDevice(0);
     GraphStd<vert_t, vert_t> graph(UNDIRECTED);
-    
+
     graph.read(argv[1], SORT | PRINT_INFO );
 
     HornetInit hornet_init(graph.nV(), graph.nE(),
@@ -68,7 +68,7 @@ int exec(int argc, char* argv[]) {
 
     gpu::allocate(gpuOffset, graph.nV()+1);
     cudaMemcpy(gpuOffset,graph.csr_out_offsets(),sizeof(vert_t)*(graph.nV()+1), cudaMemcpyHostToDevice);
-    
+
     // int temp;
 
     // int temp2=scanf("%d",&temp);
@@ -82,7 +82,7 @@ int exec(int argc, char* argv[]) {
     // ktruss.setInitParameters(1, 32, 0, 64000, 32);
     // ktruss.createOffSetArray();
     ktruss.setInitParameters(4, 8, 2, 64000, 32);
- 
+
     Timer<DEVICE> TM;
     ktruss.reset();
     TM.start();
@@ -101,7 +101,7 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);
@@ -110,4 +110,3 @@ int main(int argc, char* argv[]) {
 
   return ret;
 }
-

--- a/hornetsnest/test/KatzDynamicTest.cu
+++ b/hornetsnest/test/KatzDynamicTest.cu
@@ -92,7 +92,7 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);
@@ -101,4 +101,3 @@ int main(int argc, char* argv[]) {
 
   return ret;
 }
-

--- a/hornetsnest/test/KatzDynamicTest.cu
+++ b/hornetsnest/test/KatzDynamicTest.cu
@@ -91,8 +91,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/KatzTest.cu
+++ b/hornetsnest/test/KatzTest.cu
@@ -56,7 +56,7 @@ int exec(int argc, char* argv[]) {
     GraphStd<vert_t, vert_t> graph(UNDIRECTED);
 
     HornetInit* hornet_init;
-    
+
     if(argc>1){
       graph.read(argv[1], SORT | PRINT_INFO);
       hornet_init = new HornetInit(graph.nV(), graph.nE(), graph.csr_out_offsets(), graph.csr_out_edges());
@@ -97,7 +97,7 @@ int exec(int argc, char* argv[]) {
 
 
     // Katz kcStatIc(hornet_graph, max_iterations, max_degree_vertex);
-    float alpha = 1.0/(max_degree_vertex+1.0); 
+    float alpha = 1.0/(max_degree_vertex+1.0);
     Katz kcStatIc(hornet_graph, alpha, max_iterations);
 
 
@@ -136,11 +136,10 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec<hornets_nest::HornetStaticGraph,hornets_nest::KatzCentralityStatic>(argc, argv);
   }
 
   return ret;
 }
-

--- a/hornetsnest/test/KatzTest.cu
+++ b/hornetsnest/test/KatzTest.cu
@@ -135,8 +135,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
     ret = exec<hornets_nest::HornetStaticGraph,hornets_nest::KatzCentralityStatic>(argc, argv);
   }

--- a/hornetsnest/test/KatzTopKTest.cu
+++ b/hornetsnest/test/KatzTopKTest.cu
@@ -54,7 +54,7 @@ int exec(int argc, char* argv[]) {
 
 	  cudaSetDevice(0);
     GraphStd<vert_t, vert_t> graph(UNDIRECTED);
-    
+
     graph.read(argv[1], SORT | PRINT_INFO);
 
     HornetInit hornet_init(graph.nV(), graph.nE(), graph.csr_out_offsets(), graph.csr_out_edges());
@@ -64,7 +64,7 @@ int exec(int argc, char* argv[]) {
 	  int topK = graph.nV();
      if(argc>2)
         topK=atoi(argv[2]);
- 
+
     // Finding largest vertex degreemake
     degree_t max_degree_vertex = hornet_graph.max_degree();
     std::cout << "Max degree vextex is " << max_degree_vertex << std::endl;
@@ -83,7 +83,7 @@ int exec(int argc, char* argv[]) {
     auto total_time = TM.duration();
     std::cout << "The number of iterations     : "
               << kcPostUpdate.get_iteration_count()
-              << "\nTopK                       : " << topK 
+              << "\nTopK                       : " << topK
               << "\nTotal time for KC          : " << total_time
               << "\nAverage time per iteartion : "
               << total_time /
@@ -96,7 +96,7 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     for(int i=0; i<10; i++){
@@ -109,4 +109,3 @@ int main(int argc, char* argv[]) {
 
   return ret;
 }
-

--- a/hornetsnest/test/KatzTopKTest.cu
+++ b/hornetsnest/test/KatzTopKTest.cu
@@ -95,8 +95,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     for(int i=0; i<10; i++){

--- a/hornetsnest/test/PageRankTest.cu
+++ b/hornetsnest/test/PageRankTest.cu
@@ -50,7 +50,7 @@ int exec(int argc, char* argv[]) {
     page_rank_undir.run();
 
     TM.stop();
-    TM.print("PR---Undirected---PULL");        	
+    TM.print("PR---Undirected---PULL");
 
 
 
@@ -60,7 +60,7 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);
@@ -69,4 +69,3 @@ int main(int argc, char* argv[]) {
 
   return ret;
 }
-

--- a/hornetsnest/test/PageRankTest.cu
+++ b/hornetsnest/test/PageRankTest.cu
@@ -59,8 +59,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/SSSPTest.cu
+++ b/hornetsnest/test/SSSPTest.cu
@@ -43,8 +43,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/SSSPTest.cu
+++ b/hornetsnest/test/SSSPTest.cu
@@ -25,7 +25,7 @@ int exec(int argc, char* argv[]) {
     HornetGraph hornet_graph(hornet_init);
 
     vid_t root = 0;
-    if(argc==3) 
+    if(argc==3)
         root = atoi(argv[2]);
 
     SSSP sssp(hornet_graph);
@@ -44,7 +44,7 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);
@@ -53,4 +53,3 @@ int main(int argc, char* argv[]) {
 
   return ret;
 }
-

--- a/hornetsnest/test/SpMVTest.cu
+++ b/hornetsnest/test/SpMVTest.cu
@@ -47,8 +47,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/SpMVTest.cu
+++ b/hornetsnest/test/SpMVTest.cu
@@ -48,7 +48,7 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);
@@ -57,4 +57,3 @@ int main(int argc, char* argv[]) {
 
   return ret;
 }
-

--- a/hornetsnest/test/TriangleTest2.cu
+++ b/hornetsnest/test/TriangleTest2.cu
@@ -131,8 +131,6 @@ int exec(int argc, char* argv[]) {
 
 int main(int argc, char* argv[]) {
   int ret = 0;
-  auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);

--- a/hornetsnest/test/TriangleTest2.cu
+++ b/hornetsnest/test/TriangleTest2.cu
@@ -1,12 +1,12 @@
 /**
  * @brief Triangle counting test program
  * Based on triangle counting algorithm designed in:
- * J. Fox, O. Green, K. Gabert, X. An, D. Bader, “Fast and Adaptive List Intersections on the GPU”, 
- * IEEE High Performance Extreme Computing Conference (HPEC), 
+ * J. Fox, O. Green, K. Gabert, X. An, D. Bader, “Fast and Adaptive List Intersections on the GPU”,
+ * IEEE High Performance Extreme Computing Conference (HPEC),
  * Waltham, Massachusetts, 2018
- * O. Green, J. Fox, A. Tripathy, A. Watkins, K. Gabert, E. Kim, X. An, K. Aatish, D. Bader, 
- * “Logarithmic Radix Binning and Vectorized Triangle Counting”, 
- * IEEE High Performance Extreme Computing Conference (HPEC), 
+ * O. Green, J. Fox, A. Tripathy, A. Watkins, K. Gabert, E. Kim, X. An, K. Aatish, D. Bader,
+ * “Logarithmic Radix Binning and Vectorized Triangle Counting”,
+ * IEEE High Performance Extreme Computing Conference (HPEC),
  * Waltham, Massachusetts, 2018
  * @file
  */
@@ -26,7 +26,7 @@ using namespace hornets_nest;
 using HornetGraph = ::hornet::gpu::Hornet<vid_t>;
 
 
-// CPU Version - assume sorted index lists. 
+// CPU Version - assume sorted index lists.
 int hostSingleIntersection (const vid_t ai, const degree_t alen, const vid_t * a,
                             const vid_t bi, const degree_t blen, const vid_t * b){
 
@@ -50,8 +50,8 @@ int hostSingleIntersection (const vid_t ai, const degree_t alen, const vid_t * a
         else {
             bptr++;
         }
-      }  
-  
+      }
+
     return out;
 }
 
@@ -66,12 +66,12 @@ void hostCountTriangles (const vid_t nv, const vid_t ne, const eoff_t * off,
         for(int iter=off[src]; iter<off[src+1]; iter++)
         {
             vid_t dest=ind[iter];
-            degree_t destLen=off[dest+1]-off[dest];            
+            degree_t destLen=off[dest+1]-off[dest];
             int64_t tris= hostSingleIntersection (src, srcLen, ind+off[src],
                                                     dest, destLen, ind+off[dest]);
             sum+=tris;
         }
-    }    
+    }
     *allTriangles=sum;
     //printf("Sequential number of triangles %ld\n",sum);
 }
@@ -79,15 +79,15 @@ void hostCountTriangles (const vid_t nv, const vid_t ne, const eoff_t * off,
 
 int exec(int argc, char* argv[]) {
     int deviceCount = 0;
-    cudaGetDeviceCount(&deviceCount);      
-    std::cout << "Number of devices: " << deviceCount << std::endl; 
+    cudaGetDeviceCount(&deviceCount);
+    std::cout << "Number of devices: " << deviceCount << std::endl;
     //int device = 4;
     //cudaSetDevice(device);
     //struct cudaDeviceProp properties;
     //cudaGetDeviceProperties(&properties, device);
     //std::cout<<"using "<<properties.multiProcessorCount<<" multiprocessors"<<std::endl;
     //std::cout<<"max threads per processor: "<<properties.maxThreadsPerMultiProcessor<<std::endl;
-   
+
     using namespace graph::structure_prop;
     using namespace graph::parsing_prop;
 
@@ -99,7 +99,7 @@ int exec(int argc, char* argv[]) {
     HornetGraph hornet_graph(hornet_init);
     TriangleCounting2 tc(hornet_graph);
     tc.init();
-    
+
     int work_factor;
     if (argc > 2) {
         work_factor = atoi(argv[2]);
@@ -119,7 +119,7 @@ int exec(int argc, char* argv[]) {
 
     triangle_t deviceTriangleCount = tc.countTriangles();
     printf("Device triangles: %llu\n", deviceTriangleCount);
-  
+
     /*
     int64_t hostTriCount = 0;
     std::cout << "Starting host triangle counting" << std::endl;
@@ -132,7 +132,7 @@ int exec(int argc, char* argv[]) {
 int main(int argc, char* argv[]) {
   int ret = 0;
   auto resource = std::make_unique<rmm::mr::cnmem_memory_resource>();
-  rmm::mr::set_default_resource(resource.get());
+  rmm::mr::set_current_device_resource(resource.get());
   {
 
     ret = exec(argc, argv);
@@ -141,4 +141,3 @@ int main(int argc, char* argv[]) {
 
   return ret;
 }
-

--- a/primitives/StandardAPI.i.hpp
+++ b/primitives/StandardAPI.i.hpp
@@ -43,7 +43,7 @@
 #include <Device/Primitives/CubWrapper.cuh>
 #include <omp.h>
 #include <cstring>
-#include <rmm/mr/device/cnmem_memory_resource.hpp>
+#include <rmm/mr/device/per_device_resource.hpp>
 
 namespace hornets_nest {
 namespace gpu {

--- a/primitives/StandardAPI.i.hpp
+++ b/primitives/StandardAPI.i.hpp
@@ -51,13 +51,13 @@ namespace gpu {
 template<typename T>
 void allocate(T*& pointer, size_t num_items) {
     pointer = static_cast<T*>(
-        rmm::mr::get_default_resource()->allocate(sizeof(T)*num_items, 0));
+        rmm::mr::get_current_device_resource()->allocate(sizeof(T)*num_items, 0));
 }
 
 template<typename T>
 typename std::enable_if<std::is_pointer<T>::value>::type
 free(T& pointer, size_t num_items) {
-    rmm::mr::get_default_resource()->deallocate(static_cast<void*>(pointer), sizeof(T)*num_items, 0);
+    rmm::mr::get_current_device_resource()->deallocate(static_cast<void*>(pointer), sizeof(T)*num_items, 0);
 }
 
 template<typename T>


### PR DESCRIPTION
Replaced deprecated [gs]et_default_resource() RMM API calls with [gs]et_current_device_resource().

NOTE: Tested only by seeing build fail prior to change, made changes, observed build pass, but did not run the unit tests locally.