### PR TITLE
Update to support thrust 1.12

### DIFF
--- a/hornet/include/Core/SoA/impl/SoAPtr.i.cuh
+++ b/hornet/include/Core/SoA/impl/SoAPtr.i.cuh
@@ -35,6 +35,7 @@
  */
 
 #include <rmm/thrust_rmm_allocator.h>
+#include <thrust/host_vector.h>
 
 using namespace rmm;
 


### PR DESCRIPTION
Thrust 1.12 headers changed and we need to explicitly include thrust/host_vector.h to use thrust::host_vector.