### PR TITLE
RMM is making streams explicit in the device_buffer

### DIFF
--- a/hornet/include/Core/SoA/impl/SoADataSort.i.cuh
+++ b/hornet/include/Core/SoA/impl/SoADataSort.i.cuh
@@ -310,7 +310,7 @@ cub_segmented_sort(CSoAPtr<EdgeTypes...> &soa, degree_t capacity, degree_t segme
   cub::DeviceSegmentedRadixSort::SortKeys(
       NULL, tempStorageBytes, in_edges, out_edges, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);
-  rmm::device_buffer tempStorage(tempStorageBytes);
+  rmm::device_buffer tempStorage(tempStorageBytes, cuda_stream_view{});
   cub::DeviceSegmentedRadixSort::SortKeys(
       tempStorage.data(), tempStorageBytes, in_edges, out_edges, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);
@@ -344,7 +344,7 @@ cub_segmented_sort(CSoAPtr<EdgeTypes...> &soa, degree_t capacity, degree_t segme
   cub::DeviceSegmentedRadixSort::SortPairs(
       NULL, tempStorageBytes, in_key, out_key, in_val, out_val, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);
-  rmm::device_buffer tempStorage(tempStorageBytes);
+  rmm::device_buffer tempStorage(tempStorageBytes, cuda_stream_view{});
   cub::DeviceSegmentedRadixSort::SortPairs(
       tempStorage.data(), tempStorageBytes, in_key, out_key, in_val, out_val, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);
@@ -382,7 +382,7 @@ cub_segmented_sort(CSoAPtr<EdgeTypes...> &soa, degree_t capacity, degree_t segme
   cub::DeviceSegmentedRadixSort::SortPairs(
       NULL, tempStorageBytes, in_key, out_key, in_val, out_val, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);
-  rmm::device_buffer tempStorage(tempStorageBytes);
+  rmm::device_buffer tempStorage(tempStorageBytes, cuda_stream_view{});
   cub::DeviceSegmentedRadixSort::SortPairs(
       tempStorage.data(), tempStorageBytes, in_key, out_key, in_val, out_val, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);

--- a/xlib/include/Device/Primitives/CubWrapper.cuh
+++ b/xlib/include/Device/Primitives/CubWrapper.cuh
@@ -64,7 +64,7 @@ protected:
     explicit CubWrapper(const int num_items) noexcept : _num_items(num_items) {}
     ~CubWrapper() noexcept { release(); }
 
-    mutable rmm::device_buffer _d_temp_storage { 0 };
+    mutable rmm::device_buffer _d_temp_storage { 0, cuda_stream_view{} };
     size_t _temp_storage_bytes { 0 };
     int    _num_items          { 0 };
 };


### PR DESCRIPTION
To support https://github.com/rapidsai/rmm/pull/775, we need to add the stream parameter to the device_buffer constructor.