### PR TITLE
Updates to allow RMM to remove defaulting stream from device_buffer constructor

### DIFF
--- a/primitives/BufferPool.cuh
+++ b/primitives/BufferPool.cuh
@@ -29,6 +29,6 @@ class BufferPool {
 template <typename P>
 void
 BufferPool::allocate(P** ptr, size_t num_items) {
-  _data.emplace_back(num_items*sizeof(P));
+  _data.emplace_back(num_items*sizeof(P), cuda_stream_view{});
   *ptr = static_cast<P*>(_data.back().data());
 }

--- a/xlib/include/Device/Primitives/CubWrapper.cuh
+++ b/xlib/include/Device/Primitives/CubWrapper.cuh
@@ -206,7 +206,7 @@ void CubSortByKey<T, R>::initialize(const int max_items) noexcept {
                                     d_key, d_key_sorted,
                                     d_data_in, d_data_out,
                                     _num_items, 0, sizeof(T) * 8);
-    _d_temp_storage.resize(temp_storage_bytes);
+    _d_temp_storage.resize(temp_storage_bytes, cuda_stream_view{});
 }
 
 //------------------------------------------------------------------------------
@@ -307,7 +307,7 @@ void CubRunLengthEncode<T>::initialize(const int max_items) noexcept {
     cub::DeviceRunLengthEncode::Encode(nullptr, temp_storage_bytes,
                                        d_in, d_unique_out, d_counts_out,
                                        _d_num_runs_out.data().get(), _num_items);
-    _d_temp_storage.resize(temp_storage_bytes);
+    _d_temp_storage.resize(temp_storage_bytes, cuda_stream_view{});
 }
 
 //------------------------------------------------------------------------------
@@ -375,7 +375,7 @@ void CubExclusiveSum<T>::initialize(const int max_items) noexcept {
     cub::DeviceScan::ExclusiveSum(nullptr, temp_storage_bytes,
                                   d_in, d_out, _num_items);
     if (temp_storage_bytes)
-        _d_temp_storage.resize(temp_storage_bytes);
+        _d_temp_storage.resize(temp_storage_bytes, cuda_stream_view{});
 }
 
 //------------------------------------------------------------------------------
@@ -463,7 +463,7 @@ void CubInclusiveMax<T>::initialize(const int max_items) noexcept {
     cub::DeviceScan::InclusiveScan(nullptr, temp_storage_bytes,
                                   d_in, d_out, max_op, _num_items);
     if (temp_storage_bytes)
-        _d_temp_storage.resize(temp_storage_bytes);
+        _d_temp_storage.resize(temp_storage_bytes, cuda_stream_view{});
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Missed a few subtle changes in the last PR.  Tested this one with cugraph and rmm PRs.