### PR TITLE
Workaround fix for cuda 11.4

### DIFF
--- a/hornet/include/Core/HornetDevice/Edge.cuh
+++ b/hornet/include/Core/HornetDevice/Edge.cuh
@@ -71,7 +71,6 @@ class Edge<
 
     private:
 
-    HornetDeviceT&      _hornet;
     vid_t               _src_id;
     degree_t             _index;
     mutable EdgeContainerT _ptr;
@@ -85,6 +84,7 @@ class Edge<
         const degree_t edges_per_block);
 
     public:
+    HornetDeviceT&      _hornet;
 
     HOST_DEVICE
     vid_t

--- a/hornet/include/Core/HornetDevice/Edge.cuh
+++ b/hornet/include/Core/HornetDevice/Edge.cuh
@@ -84,6 +84,8 @@ class Edge<
         const degree_t edges_per_block);
 
     public:
+    //FIXME : Temporary fix for CUDA 11.4
+    //Move to private after resolution
     HornetDeviceT&      _hornet;
 
     HOST_DEVICE

--- a/hornet/include/Core/HornetDevice/Vertex.cuh
+++ b/hornet/include/Core/HornetDevice/Vertex.cuh
@@ -71,15 +71,14 @@ class Vertex<
         vid_t, degree_t>;
 
     private:
-
-    HornetDeviceT&  _hornet;
-
     vid_t           _id;
 
     HOST_DEVICE
     Vertex(HornetDeviceT& hornet, const vid_t id);
 
     public:
+    HornetDeviceT&  _hornet;
+
     HOST_DEVICE
     vid_t id(void) const;
 

--- a/hornet/include/Core/HornetDevice/Vertex.cuh
+++ b/hornet/include/Core/HornetDevice/Vertex.cuh
@@ -77,6 +77,8 @@ class Vertex<
     Vertex(HornetDeviceT& hornet, const vid_t id);
 
     public:
+    //FIXME : Temporary fix for CUDA 11.4
+    //Move to private after resolution
     HornetDeviceT&  _hornet;
 
     HOST_DEVICE


### PR DESCRIPTION
Make hornetdevice reference public from private.