### PR TITLE
Add thrust includes.

### DIFF
--- a/hornet/include/Core/BatchUpdate/BatchUpdate.i.cuh
+++ b/hornet/include/Core/BatchUpdate/BatchUpdate.i.cuh
@@ -38,6 +38,16 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
 
+#include <thrust/copy.h>
+#include <thrust/device_ptr.h>
+#include <thrust/fill.h>
+#include <thrust/functional.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/sequence.h>
+#include <thrust/tuple.h>
+#include <thrust/unique.h>
+
 using namespace rmm;
 
 template <typename T>
@@ -265,7 +275,7 @@ remove_duplicates_edges_only(
                 in_ptr.template get<0>(), in_ptr.template get<1>()));
     auto begin_out_tuple = thrust::make_zip_iterator(thrust::make_tuple(
                 out_ptr.template get<0>(), out_ptr.template get<1>()));
-    
+
     cudaStream_t stream{nullptr};
     auto end_ptr =
         thrust::unique_copy(

--- a/hornet/include/Core/BatchUpdate/BatchUpdateKernels.cuh
+++ b/hornet/include/Core/BatchUpdate/BatchUpdateKernels.cuh
@@ -3,6 +3,10 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
 
+#include <thrust/copy.h>
+#include <thrust/device_ptr.h>
+#include <thrust/fill.h>
+
 using namespace rmm;
 
 

--- a/hornet/include/Core/HornetInitialize/HornetInitialize.i.cuh
+++ b/hornet/include/Core/HornetInitialize/HornetInitialize.i.cuh
@@ -38,6 +38,8 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
 
+#include <thrust/copy.h>
+
 using namespace rmm;
 
 namespace hornet {

--- a/hornet/include/Core/HornetInitialize/HornetStaticInitialize.i.cuh
+++ b/hornet/include/Core/HornetInitialize/HornetStaticInitialize.i.cuh
@@ -3,6 +3,13 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
 
+#include <thrust/copy.h>
+#include <thrust/device_ptr.h>
+#include <thrust/extrema.h>
+#include <thrust/fill.h>
+#include <thrust/functional.h>
+#include <thrust/transform.h>
+
 using namespace rmm;
 
 namespace hornet {
@@ -119,7 +126,7 @@ vid_t
 HORNETSTATIC::
 max_degree_id() const noexcept {
     auto start_ptr = _vertex_data.get_soa_ptr().template get<0>();
-    cudaStream_t stream{nullptr};    
+    cudaStream_t stream{nullptr};
     auto* iter = thrust::max_element(rmm::exec_policy(stream), start_ptr, start_ptr + _nV);
     if (iter == start_ptr + _nV) {
         return static_cast<vid_t>(-1);

--- a/hornet/include/Core/HornetOperations/HornetSort.i.cuh
+++ b/hornet/include/Core/HornetOperations/HornetSort.i.cuh
@@ -17,6 +17,9 @@
 
 #include <rmm/device_vector.hpp>
 
+#include <thrust/scan.h>
+#include <thrust/transform.h>
+
 namespace hornet {
 
 namespace gpu {

--- a/hornet/include/Core/MemoryManager/lrb.cuh
+++ b/hornet/include/Core/MemoryManager/lrb.cuh
@@ -3,6 +3,9 @@
 
 #include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+
+#include <thrust/copy.h>
+
 #include <vector>
 
 ////////////////////////////////////////////////////////////////

--- a/hornet/include/Core/SoA/SoAData.cuh
+++ b/hornet/include/Core/SoA/SoAData.cuh
@@ -42,6 +42,7 @@
 #include <Device/Util/SafeCudaAPISync.cuh>
 #include <thrust/device_vector.h>
 #include <thrust/gather.h>
+#include <thrust/host_vector.h>
 #include <vector>
 
 #include <rmm/exec_policy.hpp>

--- a/hornet/include/Core/SoA/impl/SoAData.i.cuh
+++ b/hornet/include/Core/SoA/impl/SoAData.i.cuh
@@ -37,6 +37,10 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
 
+#include <thrust/copy.h>
+#include <thrust/device_ptr.h>
+#include <thrust/host_vector.h>
+
 using namespace rmm;
 
 namespace hornet {

--- a/hornet/include/Core/SoA/impl/SoADataSort.i.cuh
+++ b/hornet/include/Core/SoA/impl/SoADataSort.i.cuh
@@ -5,6 +5,11 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/device_vector.hpp>
 
+#include <thrust/functional.h>
+#include <thrust/iterator/constant_iterator.h>
+#include <thrust/sequence.h>
+#include <thrust/transform.h>
+
 namespace hornet {
 
 namespace detail {

--- a/hornet/include/Core/SoA/impl/SoAPtr.i.cuh
+++ b/hornet/include/Core/SoA/impl/SoAPtr.i.cuh
@@ -36,7 +36,16 @@
 
 #include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
+
+#include <thrust/device_ptr.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/gather.h>
 #include <thrust/host_vector.h>
+#include <thrust/iterator/zip_iterator.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+#include <thrust/tuple.h>
 
 using namespace rmm;
 
@@ -594,7 +603,7 @@ template <template <typename...> typename Ptr, typename degree_t, typename... Ed
 void
 sort_edges(Ptr<EdgeTypes...> ptr, const degree_t nE) {
     cudaStream_t stream{nullptr};
-    
+
     thrust::sort_by_key(
             rmm::exec_policy(stream),
             ptr.template get<1>(), ptr.template get<1>() + nE,

--- a/hornet/include/Core/Static/Static.cuh
+++ b/hornet/include/Core/Static/Static.cuh
@@ -13,6 +13,8 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
 
+#include <thrust/host_vector.h>
+
 using namespace rmm;
 
 namespace hornet {

--- a/hornet/include/Util/RandomGraphData.cuh
+++ b/hornet/include/Util/RandomGraphData.cuh
@@ -6,8 +6,16 @@
 #include "../Core/Static/Static.cuh"
 #include <random>                       //std::mt19937_64
 #include <utility>                       //std::mt19937_64
+
+#include <thrust/device_ptr.h>
+#include <thrust/host_vector.h>
+#include <thrust/iterator/counting_iterator.h>
 #include <thrust/random/linear_congruential_engine.h>
 #include <thrust/random/uniform_int_distribution.h>
+#include <thrust/random/uniform_real_distribution.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+#include <thrust/transform.h>
 
 #include <rmm/device_vector.hpp>
 

--- a/hornetsnest/include/Static/KTruss/KTruss.impl.cuh
+++ b/hornetsnest/include/Static/KTruss/KTruss.impl.cuh
@@ -36,6 +36,8 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <thrust/scan.h>
+
 using namespace std;
 using namespace rmm;
 
@@ -185,7 +187,7 @@ void KTruss::findTrussOfK() {
     forAllVertices(hornet, Init { hd_data });
     resetEdgeArray();
     resetVertexArray();
- 
+
     cudaMemset(hd_data().counter,0, sizeof(int));
 
     int h_active_vertices = originalNV;

--- a/hornetsnest/include/Static/KTruss/KTrussWeighted.impl.cuh
+++ b/hornetsnest/include/Static/KTruss/KTrussWeighted.impl.cuh
@@ -36,6 +36,8 @@
 
 #include <rmm/exec_policy.hpp>
 
+#include <thrust/scan.h>
+
 using namespace std;
 using namespace rmm;
 
@@ -205,7 +207,7 @@ void KTrussWeighted<T>::findTrussOfK() {
     forAllVertices(hnt, Init { hd_data });
     resetEdgeArray();
     resetVertexArray();
- 
+
     cudaMemset(hd_data().counter,0, sizeof(int));
 
     int h_active_vertices = originalNV;

--- a/hornetsnest/include/Static/KatzCentrality/Katz.cuh
+++ b/hornetsnest/include/Static/KatzCentrality/Katz.cuh
@@ -42,12 +42,14 @@
 #include <BufferPool.cuh>
 
 #include <cmath>
-#include <thrust/functional.h>
-#include <thrust/transform_reduce.h>
+
+#include <thrust/device_ptr.h>
 #include <thrust/device_vector.h>
-#include <thrust/transform.h>
-#include <thrust/inner_product.h>
 #include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+#include <thrust/inner_product.h>
+#include <thrust/transform.h>
+#include <thrust/transform_reduce.h>
 
 
 namespace hornets_nest {

--- a/hornetsnest/test/CoreNumberTest.cu
+++ b/hornetsnest/test/CoreNumberTest.cu
@@ -8,6 +8,8 @@
 #include <Device/Util/Timer.cuh>
 #include <Graph/GraphStd.hpp>
 
+#include <thrust/device_vector.h>
+
 using namespace timer;
 using namespace hornets_nest;
 

--- a/primitives/LoadBalancing/BinarySearch.cuh
+++ b/primitives/LoadBalancing/BinarySearch.cuh
@@ -37,9 +37,11 @@
  * @file
  */
 #pragma once
- 
+
 #include "BasicTypes.hpp"
 #include "Queue/TwoLevelQueue.cuh"
+
+#include <thrust/device_vector.h>
 
 namespace hornets_nest {
 /**


### PR DESCRIPTION
## Description

This PR cleans up some `#include`s for Thrust. This is meant to help ease the transition to Thrust 1.16 / 1.17 when that is updated in rapids-cmake.

Required for https://github.com/rapidsai/cugraph/pull/2310.

I am uncertain about how the build system works for this package but it seems that it should be using rapids-cmake rather than bundling cub-1.8.0.