### PR TITLE
Remove `using namespace rmm;`.

### DIFF
--- a/hornet/include/Core/BatchUpdate/BatchUpdate.cuh
+++ b/hornet/include/Core/BatchUpdate/BatchUpdate.cuh
@@ -53,9 +53,6 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
 
-using namespace rmm;
-
-
 #define CUDA_TRY_CALL( call ) 									                            \
 {                                                                     \
     cudaError_t cudaStatus = call;                                    \

--- a/hornet/include/Core/BatchUpdate/BatchUpdate.i.cuh
+++ b/hornet/include/Core/BatchUpdate/BatchUpdate.i.cuh
@@ -48,8 +48,6 @@
 #include <thrust/tuple.h>
 #include <thrust/unique.h>
 
-using namespace rmm;
-
 template <typename T>
 void print_vec(rmm::device_vector<T>& vec) {
         thrust::copy(vec.begin(), vec.end(), std::ostream_iterator<T>(std::cout, " "));

--- a/hornet/include/Core/BatchUpdate/BatchUpdateKernels.cuh
+++ b/hornet/include/Core/BatchUpdate/BatchUpdateKernels.cuh
@@ -7,9 +7,6 @@
 #include <thrust/device_ptr.h>
 #include <thrust/fill.h>
 
-using namespace rmm;
-
-
 template <typename HornetDeviceT, typename vid_t, typename degree_t>
 __global__
 void get_vertex_degrees_kernel(

--- a/hornet/include/Core/HornetInitialize/HornetInitialize.i.cuh
+++ b/hornet/include/Core/HornetInitialize/HornetInitialize.i.cuh
@@ -40,8 +40,6 @@
 
 #include <thrust/copy.h>
 
-using namespace rmm;
-
 namespace hornet {
 namespace gpu {
 

--- a/hornet/include/Core/HornetInitialize/HornetStaticInitialize.i.cuh
+++ b/hornet/include/Core/HornetInitialize/HornetStaticInitialize.i.cuh
@@ -10,8 +10,6 @@
 #include <thrust/functional.h>
 #include <thrust/transform.h>
 
-using namespace rmm;
-
 namespace hornet {
 namespace gpu {
 

--- a/hornet/include/Core/HornetOperations/HornetQuery.i.cuh
+++ b/hornet/include/Core/HornetOperations/HornetQuery.i.cuh
@@ -8,9 +8,6 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
 
-using namespace rmm;
-
-
 namespace hornet {
 namespace gpu {
   template <typename... VertexMetaTypes, typename... EdgeMetaTypes, typename vid_t, typename degree_t>

--- a/hornet/include/Core/SoA/SoAData.cuh
+++ b/hornet/include/Core/SoA/SoAData.cuh
@@ -48,8 +48,6 @@
 #include <rmm/exec_policy.hpp>
 #include <rmm/device_vector.hpp>
 
-using namespace rmm;
-
 namespace hornet {
 
 template <typename, DeviceType = DeviceType::DEVICE> class SoAData;

--- a/hornet/include/Core/SoA/impl/SoAData.i.cuh
+++ b/hornet/include/Core/SoA/impl/SoAData.i.cuh
@@ -41,8 +41,6 @@
 #include <thrust/device_ptr.h>
 #include <thrust/host_vector.h>
 
-using namespace rmm;
-
 namespace hornet {
 
 //==============================================================================

--- a/hornet/include/Core/SoA/impl/SoADataSort.i.cuh
+++ b/hornet/include/Core/SoA/impl/SoADataSort.i.cuh
@@ -316,7 +316,7 @@ cub_segmented_sort(CSoAPtr<EdgeTypes...> &soa, degree_t capacity, degree_t segme
   cub::DeviceSegmentedRadixSort::SortKeys(
       NULL, tempStorageBytes, in_edges, out_edges, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);
-  rmm::device_buffer tempStorage(tempStorageBytes, cuda_stream_view{});
+  rmm::device_buffer tempStorage(tempStorageBytes, rmm::cuda_stream_view{});
   cub::DeviceSegmentedRadixSort::SortKeys(
       tempStorage.data(), tempStorageBytes, in_edges, out_edges, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);
@@ -350,7 +350,7 @@ cub_segmented_sort(CSoAPtr<EdgeTypes...> &soa, degree_t capacity, degree_t segme
   cub::DeviceSegmentedRadixSort::SortPairs(
       NULL, tempStorageBytes, in_key, out_key, in_val, out_val, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);
-  rmm::device_buffer tempStorage(tempStorageBytes, cuda_stream_view{});
+  rmm::device_buffer tempStorage(tempStorageBytes, rmm::cuda_stream_view{});
   cub::DeviceSegmentedRadixSort::SortPairs(
       tempStorage.data(), tempStorageBytes, in_key, out_key, in_val, out_val, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);
@@ -388,7 +388,7 @@ cub_segmented_sort(CSoAPtr<EdgeTypes...> &soa, degree_t capacity, degree_t segme
   cub::DeviceSegmentedRadixSort::SortPairs(
       NULL, tempStorageBytes, in_key, out_key, in_val, out_val, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);
-  rmm::device_buffer tempStorage(tempStorageBytes, cuda_stream_view{});
+  rmm::device_buffer tempStorage(tempStorageBytes, rmm::cuda_stream_view{});
   cub::DeviceSegmentedRadixSort::SortPairs(
       tempStorage.data(), tempStorageBytes, in_key, out_key, in_val, out_val, capacity,
       offsets.size() - 1, offsets.data().get(), offsets.data().get() + 1);

--- a/hornet/include/Core/SoA/impl/SoAPtr.i.cuh
+++ b/hornet/include/Core/SoA/impl/SoAPtr.i.cuh
@@ -47,9 +47,6 @@
 #include <thrust/sort.h>
 #include <thrust/tuple.h>
 
-using namespace rmm;
-
-
 namespace hornet {
 
 //==============================================================================

--- a/hornet/include/Core/Static/Static.cuh
+++ b/hornet/include/Core/Static/Static.cuh
@@ -15,8 +15,6 @@
 
 #include <thrust/host_vector.h>
 
-using namespace rmm;
-
 namespace hornet {
 
 template <DeviceType = DeviceType::DEVICE, typename = VID_T, typename = EMPTY, typename = DEGREE_T> class COO;

--- a/hornetsnest/include/Static/KTruss/KTruss.impl.cuh
+++ b/hornetsnest/include/Static/KTruss/KTruss.impl.cuh
@@ -38,9 +38,6 @@
 
 #include <thrust/scan.h>
 
-using namespace std;
-using namespace rmm;
-
 namespace hornets_nest {
 
 void kTrussOneIteration(HornetGraph& hornet,

--- a/hornetsnest/include/Static/KTruss/KTrussWeighted.impl.cuh
+++ b/hornetsnest/include/Static/KTruss/KTrussWeighted.impl.cuh
@@ -38,9 +38,6 @@
 
 #include <thrust/scan.h>
 
-using namespace std;
-using namespace rmm;
-
 namespace hornets_nest {
 
 template <typename HornetGraphType>

--- a/xlib/include/Device/Util/CudaUtil.cuh
+++ b/xlib/include/Device/Util/CudaUtil.cuh
@@ -40,6 +40,7 @@
 
 #include <array>    //std::array
 #include <limits>   //std::numeric_limits
+#include <string>   //std::string
 
 namespace xlib {
 

--- a/xlib/src/Device/Util/CudaUtil.cpp
+++ b/xlib/src/Device/Util/CudaUtil.cpp
@@ -41,7 +41,9 @@
 #if defined(NVTX)
     #include <nvToolsExt.h>     //nvtxRangePushEx
 #endif
+
 #include <iomanip>              //std::setw
+#include <string>
 
 namespace xlib {
 


### PR DESCRIPTION
This PR removes the use of `using namespace rmm`. This fix is necessary to unblock updates in `rmm` for the `spdlog` and `fmt` dependencies.

In `"Static/KTruss/KTrussWeighted.impl.cuh"` and `"Static/KTruss/KTruss.impl.cuh"`, the presence of `using namespace rmm` broke cugraph compilation when dependencies of `rmm` were updated. In header files, `using namespace` should be strictly avoided. Reference: [C++ Core Guidelines SF.7: Don’t write using namespace at global scope in a header file](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rs-using-directive)

See also: https://github.com/rapidsai/rapids-cmake/pull/346#issuecomment-1400482248 (thanks @robertmaynard for helping identify the problem)