### PR TITLE
Use nvtx3 includes.

### DIFF
--- a/xlib/src/Device/Util/CudaUtil.cpp
+++ b/xlib/src/Device/Util/CudaUtil.cpp
@@ -39,7 +39,7 @@
 #include "Host/PrintExt.hpp"            //Color
 #include <cuda_runtime_api.h>           //cudaDeviceGetAttribute
 #if defined(NVTX)
-    #include <nvToolsExt.h>     //nvtxRangePushEx
+    #include <nvtx3/nvToolsExt.h>     //nvtxRangePushEx
 #endif
 
 #include <iomanip>              //std::setw


### PR DESCRIPTION
This PR updates cuhornet to use `#include <nvtx3/nvToolsExt.h>` instead of `#include <nvToolsExt.h>`. This ensures we fetch the header-only NVTX v3. See NVTX docs for more information: https://nvidia.github.io/NVTX/#c-and-c